### PR TITLE
Remove email param from quickstart bootstrap instructions.

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -66,7 +66,7 @@ Before you can use Gort, you have to bootstrap it by creating the `admin` user.
 You can do this using the `gort bootstrap` command and passing it the email address that your Slack provider knows you by, and the URL of the Gort controller API (by default this will be `localhost:4000`):
 
 ```bash
-$ gort bootstrap --email your.name@email.com --allow-insecure localhost:4000
+$ gort bootstrap --allow-insecure localhost:4000
 User "admin" created and credentials appended to gort config.
 ```
 


### PR DESCRIPTION
This follows the merge of https://github.com/getgort/gort/pull/78